### PR TITLE
Use requestAnimationFrame to debounce rendering

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -49,20 +49,13 @@ export class App<T> {
   }
 
   mount (el: HTMLElement): void {
-    render(
-      this.mainTemplate(
-        this.store.state,
-        this.store.send.bind(this.store),
-        this.store.state
-      ),
-      el
-    )
+    const send = this.send
 
-    const send = this.store.send.bind(this.store)
+    render(this.mainTemplate(this.store.state, send, this.store.state), el)
 
     if (this._renderOnStateChange) {
       this.store.onStateChange(
-        raf((state, prev) => {
+        raf((state: T, prev: T) => {
           render(this.mainTemplate(state, send, prev), el)
         })
       )

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import { Store, Send, Update } from './store'
 import { render, TemplateResult, SVGTemplateResult } from 'lit-html'
+import { raf } from './raf'
 export { render, html, TemplateResult, SVGTemplateResult } from 'lit-html'
 
 type InitialValue<T> = () => T
@@ -57,13 +58,14 @@ export class App<T> {
       el
     )
 
+    const send = this.store.send.bind(this.store)
+
     if (this._renderOnStateChange) {
-      this.store.onStateChange((state, prev) => {
-        render(
-          this.mainTemplate(state, this.store.send.bind(this.store), prev),
-          el
-        )
-      })
+      this.store.onStateChange(
+        raf((state, prev) => {
+          render(this.mainTemplate(state, send, prev), el)
+        })
+      )
     }
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { Store, Send } from './store'
+import { Store, Send, Update } from './store'
 import { render, TemplateResult, SVGTemplateResult } from 'lit-html'
 export { render, html, TemplateResult, SVGTemplateResult } from 'lit-html'
 
@@ -21,6 +21,7 @@ export class App<T> {
   store: Store<T>
   mainTemplate: Template<T>
   send: Send<T>
+  update: Update<T>
 
   _renderOnStateChange: boolean
 
@@ -43,6 +44,7 @@ export class App<T> {
     }
 
     this.send = this.store.send.bind(this.store)
+    this.update = this.store.update.bind(this.store)
   }
 
   mount (el: HTMLElement): void {

--- a/src/raf.ts
+++ b/src/raf.ts
@@ -1,0 +1,19 @@
+type fn = (...args: any[]) => void
+
+export function raf<F extends fn> (work: F): (...args: Parameters<F>) => void {
+  let scheduled = false
+  let latestArgs: Parameters<F>
+
+  return (...args: Parameters<F>) => {
+    latestArgs = args
+
+    if (!scheduled) {
+      scheduled = true
+
+      window.requestAnimationFrame(() => {
+        scheduled = false
+        work(latestArgs)
+      })
+    }
+  }
+}

--- a/src/raf.ts
+++ b/src/raf.ts
@@ -12,7 +12,7 @@ export function raf<F extends fn> (work: F): (...args: Parameters<F>) => void {
 
       window.requestAnimationFrame(() => {
         scheduled = false
-        work(latestArgs)
+        work(...latestArgs)
       })
     }
   }


### PR DESCRIPTION
Typesafe `raf` function to debounce rendering. The `raf` always uses the last provided args so will always be up to date, this is similar to choo's [`nanoraf`][nanoraf].

[nanoraf]: https://github.com/choojs/nanoraf/blob/master/index.js